### PR TITLE
Make the initializer in the initializers folder work.

### DIFF
--- a/lib/spree_product_zoom/engine.rb
+++ b/lib/spree_product_zoom/engine.rb
@@ -13,7 +13,9 @@ module SpreeProductZoom
       g.test_framework :rspec
     end
 
-    initializer "spree.product_zoom.preferences", :after => "spree.environment" do |app|
+    initializer("spree.product_zoom.preferences", 
+                :after => "spree.environment",
+                :before => :load_config_initializers) do |app|
       Spree::ProductZoom::Config = Spree::ProductZoomConfiguration.new
     end
 


### PR DESCRIPTION
Makes the configuration setting accessible from initializers in the initializers folder.
