### PR TITLE
fix for image undefined when using spree_product_zoom with spree_frontend 2-1-stable

### DIFF
--- a/app/views/spree/products/_image.html.erb
+++ b/app/views/spree/products/_image.html.erb
@@ -1,4 +1,4 @@
-<% if image %> 
+<% if defined?(image) && image %> 
   <%= link_to image_tag(image.attachment.url(:product), :itemprop => "image"), image.attachment.url(:original), :class => 'fancybox zoom-image' %>
   <br />
   <%= link_to image_tag('zoom.gif'), image.attachment.url(:original), :class => 'fancybox zoom-image' %>


### PR DESCRIPTION
I was experiencing a crash:

undefined local variable or method `image'

when using spree_product_zoom with the 2-1-stable branch of spree_frontend. Merging in current conditional statement from the spree_frontend to check whether the variable was defined first seems to fix everything.
